### PR TITLE
Add save_config() method to Interface

### DIFF
--- a/wpa_supplicant/core.py
+++ b/wpa_supplicant/core.py
@@ -440,6 +440,7 @@ class Interface(BaseIface):
         Method('RemoveNetwork', arguments='o'),
         Method('SelectNetwork', arguments='o'),
         Method('Disconnect'),
+        Method('SaveConfig'),
         Signal('ScanDone', 'b'),
         Signal('PropertiesChanged', 'a{sv}')
     )
@@ -524,6 +525,14 @@ class Interface(BaseIface):
         """
 
         self._call_remote('Disconnect')
+
+    def save_config(self):
+        """Save current configuration to disk
+
+        :returns: None
+        """
+
+        self._call_remote('SaveConfig')
 
     #
     # Properties


### PR DESCRIPTION
Hi,

In one of my projects I need to persist the wpa_supplicant configuration. So far it wasn't possible with this library so I resorted to `subprocess.run(['wpa_cli'], input=b'save')` which isn't very elegant.

Today I decided to PR the proper way to do this instead because it seemed to be rather easy to add. :-)

Cheers!
