### PR TITLE
Add hardcoded pip dependency versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,5 @@ nose-cov
 sphinx
 pyandoc
 tox
+click==6.7
+Twisted==17.5.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ import os
 
 install_requires = [
     'txdbus>=1.0.1',
-    'click',
+    'click==6.7',
+    'Twisted==17.5.0',
     'six',
 ]
 


### PR DESCRIPTION
Prior to this pull request, The Travis CI and local unit test suites were failing (see https://travis-ci.org/digidotcom/python-wpa-supplicant/builds/454696189). All of the unit test failures were related to version incompatibility issues with new pip dependencies.

This pull request adds explicit package versions of click and Twisted. The versions used are from the most passing Travis CI job at: https://travis-ci.org/digidotcom/python-wpa-supplicant/builds/248812490